### PR TITLE
Prevent hard crash when hoogle is not installed

### DIFF
--- a/lua/telescope/_extensions/hoogle.lua
+++ b/lua/telescope/_extensions/hoogle.lua
@@ -1,12 +1,17 @@
 if vim.fn.executable'hoogle' == 0 then
-  error("Unable to find hoogle executable on the path. Install it.")
+  vim.api.nvim_echo({{"[telescope.hoogle] Warning: Unable to find hoogle executable on the path. Install it", "WarningMsg"}}, true, {})
+  return require'telescope'.register_extension{
+    setup = function() end,
+    exports = {},
+  }
+else
+  local hoogle_builtin = require'telescope._extensions.hoogle_builtin'
+  return require'telescope'.register_extension{
+    setup = function(ext_config, _)
+      hoogle_builtin.ext_config = ext_config
+    end,
+    exports = {
+      list = hoogle_builtin.list,
+    },
+  }
 end
-local hoogle_builtin = require'telescope._extensions.hoogle_builtin'
-return require'telescope'.register_extension{
-  setup = function(ext_config, _)
-    hoogle_builtin.ext_config = ext_config
-  end,
-  exports = {
-    list = hoogle_builtin.list,
-  },
-}


### PR DESCRIPTION
If Hoogle is not installed, the plugin currently calls error, which halts the entire Neovim config from loading. This PR prevents the hard crash by printing a warning instead.